### PR TITLE
Updates to align with behaviour of spring-cloud-function

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 	<version>1.0.0.BUILD-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
-	<name>spring-cloud-function-adpater-parent</name>
+	<name>spring-cloud-function-adapter-parent</name>
 
 	<dependencyManagement>
 		<dependencies>

--- a/spring-cloud-function-adapter-aws/pom.xml
+++ b/spring-cloud-function-adapter-aws/pom.xml
@@ -8,13 +8,13 @@
 	<version>1.0.0.BUILD-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
-	<name>spring-cloud-function-adpater-aws</name>
+	<name>spring-cloud-function-adapter-aws</name>
 	<description>AWS Lambda Adapter for Spring Cloud Function</description>
 
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>1.5.0.BUILD-SNAPSHOT</version>
+		<version>1.5.3.RELEASE</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 
@@ -28,7 +28,7 @@
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-web</artifactId>
+			<artifactId>spring-boot-starter</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>com.amazonaws</groupId>
@@ -48,7 +48,7 @@
 		<dependency>
 			<groupId>io.projectreactor</groupId>
 			<artifactId>reactor-core</artifactId>
-			<version>3.0.4.RELEASE</version>
+			<version>3.0.7.RELEASE</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -68,26 +68,6 @@
 			</dependency>
 		</dependencies>
 	</dependencyManagement>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-shade-plugin</artifactId>
-				<configuration>
-					<createDependencyReducedPom>false</createDependencyReducedPom>
-				</configuration>
-				<executions>
-					<execution>
-						<phase>package</phase>
-						<goals>
-							<goal>shade</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-		</plugins>
-	</build>
 
 	<repositories>
 		<repository>

--- a/spring-cloud-function-adapter-sample/pom.xml
+++ b/spring-cloud-function-adapter-sample/pom.xml
@@ -8,13 +8,13 @@
 	<version>1.0.0.BUILD-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
-	<name>spring-cloud-function-adpater-sample</name>
+	<name>spring-cloud-function-adapter-sample</name>
 	<description>Spring Cloud Function Sample</description>
 
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>1.5.0.BUILD-SNAPSHOT</version>
+		<version>1.5.3.RELEASE</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 
@@ -22,7 +22,6 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<java.version>1.8</java.version>
-		<aws-lambda.version>1.1.0</aws-lambda.version>
 	</properties>
 
 	<dependencies>
@@ -34,12 +33,17 @@
 		<dependency>
 			<groupId>io.projectreactor</groupId>
 			<artifactId>reactor-core</artifactId>
-			<version>3.0.4.RELEASE</version>
+			<version>3.0.7.RELEASE</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-configuration-processor</artifactId>
+			<optional>true</optional>
 		</dependency>
 	</dependencies>
 

--- a/spring-cloud-function-adapter-sample/src/main/java/example/Config.java
+++ b/spring-cloud-function-adapter-sample/src/main/java/example/Config.java
@@ -16,7 +16,9 @@
 
 package example;
 
+import java.util.Map;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -29,11 +31,18 @@ import reactor.core.publisher.Flux;
 @EnableConfigurationProperties(Properties.class)
 public class Config {
 
-	@Autowired
 	private Properties props;
 
+	@Autowired
+	public Config(Properties props) {
+		this.props = props;
+	}
+
 	@Bean
-	public Function<Flux<String>, Flux<String>> function() {
-		return f -> f.map(s -> s.toUpperCase() + "-" + props.getFoo());
+	public Function<Flux<Map<String, String>>, Flux<Map<String, String>>> function() {
+		return f -> f.map(m -> m.entrySet().stream()
+				.collect(Collectors.toMap(e -> e.getKey(),
+						e -> e.getValue().toString().toUpperCase()
+								+ (props.getFoo() != null ? "-" + props.getFoo() : ""))));
 	}
 }

--- a/spring-cloud-function-adapter-sample/src/main/java/example/Handler.java
+++ b/spring-cloud-function-adapter-sample/src/main/java/example/Handler.java
@@ -16,16 +16,18 @@
 
 package example;
 
+import java.util.Map;
+
 import org.springframework.cloud.function.adapter.aws.AbstractFunctionInvokingEventHandler;
 
-public class Handler extends AbstractFunctionInvokingEventHandler<String> {
+public class Handler extends AbstractFunctionInvokingEventHandler<Map<String,Object>> {
 
 	public Handler() {
 		super(Config.class);
 	}
 
 	@Override
-	protected String convertEvent(String event) {
+	protected Object convertEvent(Map<String, Object> event) {
 		return event;
 	}
 }

--- a/spring-cloud-function-adapter-sample/src/main/java/example/Properties.java
+++ b/spring-cloud-function-adapter-sample/src/main/java/example/Properties.java
@@ -18,7 +18,7 @@ package example;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
-@ConfigurationProperties
+@ConfigurationProperties("app")
 public class Properties {
 
 	public String foo;

--- a/spring-cloud-function-adapter-sample/src/test/java/example/MapTests.java
+++ b/spring-cloud-function-adapter-sample/src/test/java/example/MapTests.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2016-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package example;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import reactor.core.publisher.Flux;
+
+/**
+ * @author Dave Syer
+ *
+ */
+public class MapTests {
+
+	@Test
+	public void test() {
+		Map<String, String> map = new LinkedHashMap<>();
+		map.put("one", "foo");
+		map.put("two", "bar");
+		Flux<Map<String, String>> result = new Config(new Properties()).function()
+				.apply(Flux.just(map));
+		assertThat(result.blockFirst()).containsValue("FOO");
+	}
+
+}


### PR DESCRIPTION
The function invoker now works with a single or multiple valued
input. It still doesn't use spring-cloud-function to identify the
function, but you can work with POJOs.