### PR TITLE
Fix version of AWS events jar

### DIFF
--- a/spring-cloud-function-adapter-aws/pom.xml
+++ b/spring-cloud-function-adapter-aws/pom.xml
@@ -23,6 +23,7 @@
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<java.version>1.8</java.version>
 		<aws-lambda.version>1.1.0</aws-lambda.version>
+		<aws-lambda-events.version>1.2.1</aws-lambda-events.version>
 	</properties>
 
 	<dependencies>
@@ -38,7 +39,7 @@
 		<dependency>
 			<groupId>com.amazonaws</groupId>
 			<artifactId>aws-lambda-java-events</artifactId>
-			<version>${aws-lambda.version}</version>
+			<version>${aws-lambda-events.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>com.amazonaws</groupId>


### PR DESCRIPTION
The old one downloaded all of maven central because they used
version ranges.